### PR TITLE
chore: update runner image to ubuntu-slim

### DIFF
--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build And Push Docker Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-slim
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
Replace ubuntu-20.04 with ubuntu-slim in GitHub Actions workflows as requested.